### PR TITLE
Refactor island generator with Biome resource

### DIFF
--- a/IslandGeneration/Biome.gd
+++ b/IslandGeneration/Biome.gd
@@ -2,5 +2,5 @@ extends Resource
 class_name Biome
 
 @export var name: String = ""
-@export var max_height: float = 0.0
+@export var max_height: float = 1.0
 @export var color: Color = Color.WHITE

--- a/IslandGeneration/Biome.gd
+++ b/IslandGeneration/Biome.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name Biome
+
+@export var name: String = ""
+@export var max_height: float = 0.0
+@export var color: Color = Color.WHITE

--- a/IslandGeneration/Biome.gd.uid
+++ b/IslandGeneration/Biome.gd.uid
@@ -1,0 +1,1 @@
+uid://d2ubhr7dafolu

--- a/IslandGeneration/LandHeights.gd
+++ b/IslandGeneration/LandHeights.gd
@@ -1,5 +1,0 @@
-extends Resource
-class_name LandHeights
-@export var sand: float = 0.1
-@export var grass: float = 0.11
-@export var forest: float = 0.2

--- a/IslandGeneration/LandHeights.gd.uid
+++ b/IslandGeneration/LandHeights.gd.uid
@@ -1,1 +1,0 @@
-uid://he307x1qs1nr

--- a/IslandGeneration/island_generator.gd
+++ b/IslandGeneration/island_generator.gd
@@ -7,7 +7,7 @@ class_name IslandGenerator
 @export var noise_scale_detail: float = 8.0
 @export var noise_weight_detail: float = 0.25
 @export var starting_seed: int = 42
-@export var land_heights: LandHeights
+@export var biomes: Array[Biome] = []
 @export var center_bias: float = 3.0
 @export var height_adjustment: float = 0.0
 
@@ -47,15 +47,11 @@ func generate_map() -> Dictionary:
             if normalized_dist > 1.0:
                 height = 0
 
-            var color: Color
-            if height < land_heights.sand:
-                color = Color(0.0, 0.0, 0.0, 0.0)
-            elif height < land_heights.grass:
-                color = Color(0.95, 0.89, 0.55, 1.0)
-            elif height < land_heights.forest:
-                color = Color(0.35, 0.65, 0.25, 1.0)
-            else:
-                color = Color(0.15, 0.35, 0.13, 1.0)
+            var color: Color = Color(0.0, 0.0, 0.0, 0.0)
+            for biome in biomes:
+                if height < biome.max_height:
+                    color = biome.color
+                    break
             img.set_pixel(x, y, color)
 
     img.generate_mipmaps()

--- a/Scenes/Main/Main.tscn
+++ b/Scenes/Main/Main.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://csjlsvgm6cf7k"]
+[gd_scene load_steps=13 format=3 uid="uid://csjlsvgm6cf7k"]
 
 [ext_resource type="Script" uid="uid://cunwi2033q3mc" path="res://Scenes/Main/main.gd" id="1_qtv3y"]
 [ext_resource type="PackedScene" uid="uid://ohoiqeiuqx0l" path="res://IslandGeneration/IslandRenderer.tscn" id="2_cmk6n"]
 [ext_resource type="PackedScene" uid="uid://oh0smqr43x1u" path="res://Water/Water.tscn" id="2_i3fi7"]
 [ext_resource type="Script" uid="uid://d2ubhr7dafolu" path="res://IslandGeneration/Biome.gd" id="3_biome"]
-[ext_resource type="Script" uid="uid://xk42q9y1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
-
+[ext_resource type="Script" uid="uid://xk42ray1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
 
 [sub_resource type="Resource" id="Resource_biome_sand"]
 script = ExtResource("3_biome")
@@ -17,19 +16,33 @@ color = Color(0, 0, 0, 0)
 script = ExtResource("3_biome")
 name = "Grass"
 max_height = 0.15
-color = Color(0.95, 0.89, 0.55, 1.0)
+color = Color(0.95, 0.89, 0.55, 1)
 
 [sub_resource type="Resource" id="Resource_biome_forest"]
 script = ExtResource("3_biome")
 name = "Forest"
 max_height = 0.2
-color = Color(0.35, 0.65, 0.25, 1.0)
+color = Color(0.35, 0.65, 0.25, 1)
 
 [sub_resource type="Resource" id="Resource_biome_dense"]
 script = ExtResource("3_biome")
 name = "DenseForest"
+max_height = 0.3
+color = Color(0.15, 0.35, 0.13, 1)
+
+[sub_resource type="Resource" id="Resource_o8wgc"]
+script = ExtResource("3_biome")
+name = "Mountain Base"
+max_height = 0.35
+color = Color(0.61339, 0.61339, 0.61339, 1)
+metadata/_custom_type_script = "uid://d2ubhr7dafolu"
+
+[sub_resource type="Resource" id="Resource_w20t6"]
+script = ExtResource("3_biome")
+name = "Mountain Peaks"
 max_height = 1.0
-color = Color(0.15, 0.35, 0.13, 1.0)
+color = Color(1, 1, 1, 1)
+metadata/_custom_type_script = "uid://d2ubhr7dafolu"
 
 [sub_resource type="Resource" id="Resource_island_gen"]
 script = ExtResource("4_map")
@@ -38,9 +51,9 @@ noise_scale = 128.0
 noise_scale_detail = 32.0
 noise_weight_detail = 0.15
 starting_seed = -1
-biomes = [SubResource("Resource_biome_sand"), SubResource("Resource_biome_grass"), SubResource("Resource_biome_forest"), SubResource("Resource_biome_dense")]
+biomes = Array[ExtResource("3_biome")]([SubResource("Resource_biome_sand"), SubResource("Resource_biome_grass"), SubResource("Resource_biome_forest"), SubResource("Resource_biome_dense"), SubResource("Resource_o8wgc"), SubResource("Resource_w20t6")])
 center_bias = 1.0
-height_adjustment = 5.0
+height_adjustment = 10.0
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_qtv3y")

--- a/Scenes/Main/Main.tscn
+++ b/Scenes/Main/Main.tscn
@@ -1,17 +1,35 @@
-[gd_scene load_steps=8 format=3 uid="uid://csjlsvgm6cf7k"]
+[gd_scene load_steps=11 format=3 uid="uid://csjlsvgm6cf7k"]
 
 [ext_resource type="Script" uid="uid://cunwi2033q3mc" path="res://Scenes/Main/main.gd" id="1_qtv3y"]
 [ext_resource type="PackedScene" uid="uid://ohoiqeiuqx0l" path="res://IslandGeneration/IslandRenderer.tscn" id="2_cmk6n"]
 [ext_resource type="PackedScene" uid="uid://oh0smqr43x1u" path="res://Water/Water.tscn" id="2_i3fi7"]
-[ext_resource type="Script" uid="uid://he307x1qs1nr" path="res://IslandGeneration/LandHeights.gd" id="3_cmk6n"]
-[ext_resource type="Script" uid="uid://xk42ray1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
+[ext_resource type="Script" uid="uid://d2ubhr7dafolu" path="res://IslandGeneration/Biome.gd" id="3_biome"]
+[ext_resource type="Script" uid="uid://xk42q9y1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
 
-[sub_resource type="Resource" id="Resource_i3fi7"]
-script = ExtResource("3_cmk6n")
-sand = 0.1
-grass = 0.15
-forest = 0.2
-metadata/_custom_type_script = "uid://he307x1qs1nr"
+
+[sub_resource type="Resource" id="Resource_biome_sand"]
+script = ExtResource("3_biome")
+name = "Sand"
+max_height = 0.1
+color = Color(0, 0, 0, 0)
+
+[sub_resource type="Resource" id="Resource_biome_grass"]
+script = ExtResource("3_biome")
+name = "Grass"
+max_height = 0.15
+color = Color(0.95, 0.89, 0.55, 1.0)
+
+[sub_resource type="Resource" id="Resource_biome_forest"]
+script = ExtResource("3_biome")
+name = "Forest"
+max_height = 0.2
+color = Color(0.35, 0.65, 0.25, 1.0)
+
+[sub_resource type="Resource" id="Resource_biome_dense"]
+script = ExtResource("3_biome")
+name = "DenseForest"
+max_height = 1.0
+color = Color(0.15, 0.35, 0.13, 1.0)
 
 [sub_resource type="Resource" id="Resource_island_gen"]
 script = ExtResource("4_map")
@@ -20,7 +38,7 @@ noise_scale = 128.0
 noise_scale_detail = 32.0
 noise_weight_detail = 0.15
 starting_seed = -1
-land_heights = SubResource("Resource_i3fi7")
+biomes = [SubResource("Resource_biome_sand"), SubResource("Resource_biome_grass"), SubResource("Resource_biome_forest"), SubResource("Resource_biome_dense")]
 center_bias = 1.0
 height_adjustment = 5.0
 


### PR DESCRIPTION
## Summary
- add Biome resource to make terrain definition extensible
- remove LandHeights resource
- update island generator to color map based on Biomes
- update main scene to define Biome resources

## Testing
- `bash tests/run_all_tests.sh` *(fails: Can't load script)*
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --editor --quit`


------
https://chatgpt.com/codex/tasks/task_e_684be92a5c84832eb5c2e6127dadb7fd