### PR TITLE
Add map modifier framework with rivers

### DIFF
--- a/IslandGeneration/Biome.gd
+++ b/IslandGeneration/Biome.gd
@@ -2,5 +2,5 @@ extends Resource
 class_name Biome
 
 @export var name: String = ""
-@export var max_height: float = 1.0
+@export var min_height: float = 1.0
 @export var color: Color = Color.WHITE

--- a/IslandGeneration/Modifiers/MapModifier.gd
+++ b/IslandGeneration/Modifiers/MapModifier.gd
@@ -1,0 +1,5 @@
+extends Resource
+class_name MapModifier
+
+func apply(generator: IslandGenerator, image: Image) -> void:
+    pass

--- a/IslandGeneration/Modifiers/MapModifier.gd.uid
+++ b/IslandGeneration/Modifiers/MapModifier.gd.uid
@@ -1,0 +1,1 @@
+uid://232ig0rvy8pb

--- a/IslandGeneration/Modifiers/RiverModifier.gd
+++ b/IslandGeneration/Modifiers/RiverModifier.gd
@@ -1,0 +1,75 @@
+extends MapModifier
+class_name RiverModifier
+
+@export var river_color: Color = Color(0.2, 0.4, 1.0, 1.0)
+@export var max_length: int = 200
+@export var start_search_attempts: int = 100
+
+func _calculate_height(generator: IslandGenerator, noise: FastNoiseLite, noise_detail: FastNoiseLite, pos: Vector2i, center: Vector2i, max_x: int, max_y: int) -> float:
+    var h = noise.get_noise_2d(pos.x, pos.y)
+    h += noise_detail.get_noise_2d(pos.x, pos.y) * generator.noise_weight_detail
+    var dx = abs(pos.x - center.x) / float(max_x) if max_x > 0 else 0
+    var dy = abs(pos.y - center.y) / float(max_y) if max_y > 0 else 0
+    var nd = max(dx, dy)
+    if max_x > 0 and max_y > 0:
+        h *= pow(1 - nd, 1 + generator.center_bias)
+    h += generator.height_adjustment * 0.01
+    if nd > 1.0:
+        h = 0
+    return h
+
+func apply(generator: IslandGenerator, image: Image) -> void:
+    var noise := FastNoiseLite.new()
+    noise.noise_type = FastNoiseLite.TYPE_PERLIN
+    noise.frequency = 1.0 / generator.noise_scale
+    noise.seed = generator.starting_seed
+
+    var noise_detail := FastNoiseLite.new()
+    noise_detail.noise_type = FastNoiseLite.TYPE_PERLIN
+    noise_detail.frequency = 1.0 / generator.noise_scale_detail
+    noise_detail.seed = generator.starting_seed + 1
+
+    var center := generator.island_size / 2
+    var max_x = center.x
+    var max_y = center.y
+
+    var start_pos := Vector2i.ZERO
+    var found := false
+    for _i in start_search_attempts:
+        var x = randi() % generator.island_size.x
+        var y = randi() % generator.island_size.y
+        var h = _calculate_height(generator, noise, noise_detail, Vector2i(x, y), center, max_x, max_y)
+        if h >= generator.biomes[-1].max_height:
+            start_pos = Vector2i(x, y)
+            found = true
+            break
+    if not found:
+        return
+
+    var pos := start_pos
+    for _i in max_length:
+        if pos.x < 0 or pos.x >= generator.island_size.x or pos.y < 0 or pos.y >= generator.island_size.y:
+            break
+        var c := image.get_pixelv(pos)
+        if c.a == 0.0:
+            break
+        image.set_pixelv(pos, river_color)
+
+        var neighbors = [
+            pos + Vector2i(1, 0),
+            pos + Vector2i(-1, 0),
+            pos + Vector2i(0, 1),
+            pos + Vector2i(0, -1)
+        ]
+        var best_neighbor := pos
+        var best_height = 999.0
+        for n in neighbors:
+            if n.x < 0 or n.x >= generator.island_size.x or n.y < 0 or n.y >= generator.island_size.y:
+                continue
+            var h = _calculate_height(generator, noise, noise_detail, n, center, max_x, max_y)
+            if h < best_height:
+                best_height = h
+                best_neighbor = n
+        if best_neighbor == pos:
+            break
+        pos = best_neighbor

--- a/IslandGeneration/Modifiers/RiverModifier.gd
+++ b/IslandGeneration/Modifiers/RiverModifier.gd
@@ -2,8 +2,10 @@ extends MapModifier
 class_name RiverModifier
 
 @export var river_color: Color = Color(0.2, 0.4, 1.0, 1.0)
-@export var max_length: int = 200
+@export var max_length: int = 20000
 @export var start_search_attempts: int = 100
+@export var river_count: int = 10
+@export var min_starting_height: float = 0.2
 
 func _calculate_height(generator: IslandGenerator, noise: FastNoiseLite, noise_detail: FastNoiseLite, pos: Vector2i, center: Vector2i, max_x: int, max_y: int) -> float:
     var h = noise.get_noise_2d(pos.x, pos.y)
@@ -17,6 +19,68 @@ func _calculate_height(generator: IslandGenerator, noise: FastNoiseLite, noise_d
     if nd > 1.0:
         h = 0
     return h
+
+func _generate_river(generator: IslandGenerator, image: Image, noise: FastNoiseLite, noise_detail: FastNoiseLite, center: Vector2i, max_x: int, max_y: int) -> void:
+    var start_pos := Vector2i.ZERO
+    var found := false
+
+    for _i in start_search_attempts:
+        var x = randi() % generator.island_size.x
+        var y = randi() % generator.island_size.y
+        var h = _calculate_height(generator, noise, noise_detail, Vector2i(x, y), center, max_x, max_y)
+
+        if h >= min_starting_height:
+            start_pos = Vector2i(x, y)
+            found = true
+            break
+    if not found:
+        print("RiverModifier: No valid starting position found after", start_search_attempts, "attempts.")
+        return
+
+    var pos := start_pos
+    var direction := Vector2(randf() * 2.0 - 1.0, randf() * 2.0 - 1.0).normalized()
+    var bend_freq := 0.08 + randf() * 0.08 # Frequency of bends
+    var bend_strength := 0.7 + randf() * 0.5 # How strong the bends are
+
+    for i in max_length:
+        if pos.x < 0 or pos.x >= generator.island_size.x or pos.y < 0 or pos.y >= generator.island_size.y:
+            break
+        var c := image.get_pixelv(pos)
+        if c.a == 0.0:
+            break
+        image.set_pixelv(pos, river_color)
+
+        # Calculate bend using sine and cosine for smooth curves
+        var angle = sin(i * bend_freq) * bend_strength
+        var perp = Vector2(-direction.y, direction.x) # Perpendicular vector
+        var bend_dir = (direction + perp * angle).normalized()
+
+        # Find the best downhill neighbor in the general bend direction
+        var best_neighbor := pos
+        var best_height = 999.0
+        var best_dot = -1.0
+        for dx in range(-1, 2):
+            for dy in range(-1, 2):
+                if dx == 0 and dy == 0:
+                    continue
+                var n = pos + Vector2i(dx, dy)
+                if n.x < 0 or n.x >= generator.island_size.x or n.y < 0 or n.y >= generator.island_size.y:
+                    continue
+                var h = _calculate_height(generator, noise, noise_detail, n, center, max_x, max_y)
+                var dir_vec = Vector2(n - pos).normalized()
+                var dot = bend_dir.dot(dir_vec)
+                # Prefer lower height and direction close to bend_dir
+                if h < best_height or (h == best_height and dot > best_dot):
+                    best_height = h
+                    best_neighbor = n
+                    best_dot = dot
+
+        if best_neighbor == pos:
+            break
+
+        # Smoothly update direction toward the chosen neighbor
+        direction = (direction * 0.7 + Vector2(best_neighbor - pos).normalized() * 0.3).normalized()
+        pos = best_neighbor
 
 func apply(generator: IslandGenerator, image: Image) -> void:
     var noise := FastNoiseLite.new()
@@ -33,43 +97,5 @@ func apply(generator: IslandGenerator, image: Image) -> void:
     var max_x = center.x
     var max_y = center.y
 
-    var start_pos := Vector2i.ZERO
-    var found := false
-    for _i in start_search_attempts:
-        var x = randi() % generator.island_size.x
-        var y = randi() % generator.island_size.y
-        var h = _calculate_height(generator, noise, noise_detail, Vector2i(x, y), center, max_x, max_y)
-        if h >= generator.biomes[-1].max_height:
-            start_pos = Vector2i(x, y)
-            found = true
-            break
-    if not found:
-        return
-
-    var pos := start_pos
-    for _i in max_length:
-        if pos.x < 0 or pos.x >= generator.island_size.x or pos.y < 0 or pos.y >= generator.island_size.y:
-            break
-        var c := image.get_pixelv(pos)
-        if c.a == 0.0:
-            break
-        image.set_pixelv(pos, river_color)
-
-        var neighbors = [
-            pos + Vector2i(1, 0),
-            pos + Vector2i(-1, 0),
-            pos + Vector2i(0, 1),
-            pos + Vector2i(0, -1)
-        ]
-        var best_neighbor := pos
-        var best_height = 999.0
-        for n in neighbors:
-            if n.x < 0 or n.x >= generator.island_size.x or n.y < 0 or n.y >= generator.island_size.y:
-                continue
-            var h = _calculate_height(generator, noise, noise_detail, n, center, max_x, max_y)
-            if h < best_height:
-                best_height = h
-                best_neighbor = n
-        if best_neighbor == pos:
-            break
-        pos = best_neighbor
+    for _i in river_count:
+        _generate_river(generator, image, noise, noise_detail, center, max_x, max_y)

--- a/IslandGeneration/Modifiers/RiverModifier.gd.uid
+++ b/IslandGeneration/Modifiers/RiverModifier.gd.uid
@@ -1,0 +1,1 @@
+uid://bav73ikqeuefi

--- a/IslandGeneration/island_generator.gd
+++ b/IslandGeneration/island_generator.gd
@@ -8,6 +8,7 @@ class_name IslandGenerator
 @export var noise_weight_detail: float = 0.25
 @export var starting_seed: int = 42
 @export var biomes: Array[Biome] = []
+@export var modifiers: Array[MapModifier] = []
 @export var center_bias: float = 3.0
 @export var height_adjustment: float = 0.0
 
@@ -53,6 +54,9 @@ func generate_map() -> Dictionary:
                     color = biome.color
                     break
             img.set_pixel(x, y, color)
+
+    for modifier in modifiers:
+        modifier.apply(self, img)
 
     img.generate_mipmaps()
     var texture := ImageTexture.create_from_image(img)

--- a/IslandGeneration/island_generator.gd
+++ b/IslandGeneration/island_generator.gd
@@ -12,6 +12,7 @@ class_name IslandGenerator
 @export var center_bias: float = 3.0
 @export var height_adjustment: float = 0.0
 
+
 func generate_map() -> Dictionary:
     var seed = starting_seed
     if starting_seed == -1:
@@ -49,8 +50,11 @@ func generate_map() -> Dictionary:
                 height = 0
 
             var color: Color = Color(0.0, 0.0, 0.0, 0.0)
-            for biome in biomes:
-                if height < biome.max_height:
+            for i in biomes.size():
+                var biome = biomes[i]
+                var next_biome = biomes[i + 1] if i + 1 < biomes.size() else null
+                var max_height = next_biome.min_height if next_biome else 1.00
+                if height >= biome.min_height and height < max_height:
                     color = biome.color
                     break
             img.set_pixel(x, y, color)

--- a/Scenes/Main/Main.tscn
+++ b/Scenes/Main/Main.tscn
@@ -1,52 +1,58 @@
-[gd_scene load_steps=15 format=3 uid="uid://csjlsvgm6cf7k"]
+[gd_scene load_steps=16 format=3 uid="uid://csjlsvgm6cf7k"]
 
 [ext_resource type="Script" uid="uid://cunwi2033q3mc" path="res://Scenes/Main/main.gd" id="1_qtv3y"]
 [ext_resource type="PackedScene" uid="uid://ohoiqeiuqx0l" path="res://IslandGeneration/IslandRenderer.tscn" id="2_cmk6n"]
 [ext_resource type="PackedScene" uid="uid://oh0smqr43x1u" path="res://Water/Water.tscn" id="2_i3fi7"]
 [ext_resource type="Script" uid="uid://d2ubhr7dafolu" path="res://IslandGeneration/Biome.gd" id="3_biome"]
 [ext_resource type="Script" uid="uid://xk42ray1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
+[ext_resource type="Script" uid="uid://232ig0rvy8pb" path="res://IslandGeneration/Modifiers/MapModifier.gd" id="5_aw1lf"]
 [ext_resource type="Script" uid="uid://bav73ikqeuefi" path="res://IslandGeneration/Modifiers/RiverModifier.gd" id="5_river"]
 
 [sub_resource type="Resource" id="Resource_biome_sand"]
 script = ExtResource("3_biome")
 name = "Sand"
-max_height = 0.1
-color = Color(0, 0, 0, 0)
+min_height = 0.05
+color = Color(1, 0.992667, 0.56, 1)
 
 [sub_resource type="Resource" id="Resource_biome_grass"]
 script = ExtResource("3_biome")
 name = "Grass"
-max_height = 0.15
-color = Color(0.95, 0.89, 0.55, 1)
+min_height = 0.1
+color = Color(0.47586, 0.84, 0.4116, 1)
 
 [sub_resource type="Resource" id="Resource_biome_forest"]
 script = ExtResource("3_biome")
 name = "Forest"
-max_height = 0.2
-color = Color(0.35, 0.65, 0.25, 1)
+min_height = 0.15
+color = Color(0.216209, 0.411782, 0.151545, 1)
 
 [sub_resource type="Resource" id="Resource_biome_dense"]
 script = ExtResource("3_biome")
 name = "DenseForest"
-max_height = 0.3
-color = Color(0.15, 0.35, 0.13, 1)
+min_height = 0.2
+color = Color(0.105197, 0.260583, 0.0896422, 1)
 
 [sub_resource type="Resource" id="Resource_o8wgc"]
 script = ExtResource("3_biome")
 name = "Mountain Base"
-max_height = 0.35
+min_height = 0.25
 color = Color(0.61339, 0.61339, 0.61339, 1)
 metadata/_custom_type_script = "uid://d2ubhr7dafolu"
 
 [sub_resource type="Resource" id="Resource_w20t6"]
 script = ExtResource("3_biome")
 name = "Mountain Peaks"
-max_height = 1.0
+min_height = 0.3
 color = Color(1, 1, 1, 1)
 metadata/_custom_type_script = "uid://d2ubhr7dafolu"
 
 [sub_resource type="Resource" id="Resource_river_mod"]
 script = ExtResource("5_river")
+river_color = Color(0.4, 0.95, 1, 1)
+max_length = 20000
+start_search_attempts = 1000
+river_count = 10
+min_starting_height = 0.2
 
 [sub_resource type="Resource" id="Resource_island_gen"]
 script = ExtResource("4_map")
@@ -56,9 +62,9 @@ noise_scale_detail = 32.0
 noise_weight_detail = 0.15
 starting_seed = -1
 biomes = Array[ExtResource("3_biome")]([SubResource("Resource_biome_sand"), SubResource("Resource_biome_grass"), SubResource("Resource_biome_forest"), SubResource("Resource_biome_dense"), SubResource("Resource_o8wgc"), SubResource("Resource_w20t6")])
+modifiers = Array[ExtResource("5_aw1lf")]([SubResource("Resource_river_mod")])
 center_bias = 1.0
-height_adjustment = 7.0
-modifiers = Array[ExtResource("5_river")]([SubResource("Resource_river_mod")])
+height_adjustment = 4.0
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_qtv3y")

--- a/Scenes/Main/Main.tscn
+++ b/Scenes/Main/Main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://csjlsvgm6cf7k"]
+[gd_scene load_steps=15 format=3 uid="uid://csjlsvgm6cf7k"]
 
 [ext_resource type="Script" uid="uid://cunwi2033q3mc" path="res://Scenes/Main/main.gd" id="1_qtv3y"]
 [ext_resource type="PackedScene" uid="uid://ohoiqeiuqx0l" path="res://IslandGeneration/IslandRenderer.tscn" id="2_cmk6n"]
 [ext_resource type="PackedScene" uid="uid://oh0smqr43x1u" path="res://Water/Water.tscn" id="2_i3fi7"]
 [ext_resource type="Script" uid="uid://d2ubhr7dafolu" path="res://IslandGeneration/Biome.gd" id="3_biome"]
 [ext_resource type="Script" uid="uid://xk42ray1r42m" path="res://IslandGeneration/island_generator.gd" id="4_map"]
+[ext_resource type="Script" uid="uid://bav73ikqeuefi" path="res://IslandGeneration/Modifiers/RiverModifier.gd" id="5_river"]
 
 [sub_resource type="Resource" id="Resource_biome_sand"]
 script = ExtResource("3_biome")
@@ -44,6 +45,9 @@ max_height = 1.0
 color = Color(1, 1, 1, 1)
 metadata/_custom_type_script = "uid://d2ubhr7dafolu"
 
+[sub_resource type="Resource" id="Resource_river_mod"]
+script = ExtResource("5_river")
+
 [sub_resource type="Resource" id="Resource_island_gen"]
 script = ExtResource("4_map")
 island_size = Vector2i(256, 128)
@@ -54,6 +58,7 @@ starting_seed = -1
 biomes = Array[ExtResource("3_biome")]([SubResource("Resource_biome_sand"), SubResource("Resource_biome_grass"), SubResource("Resource_biome_forest"), SubResource("Resource_biome_dense"), SubResource("Resource_o8wgc"), SubResource("Resource_w20t6")])
 center_bias = 1.0
 height_adjustment = 7.0
+modifiers = Array[ExtResource("5_river")]([SubResource("Resource_river_mod")])
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_qtv3y")


### PR DESCRIPTION
## Summary
- introduce `MapModifier` base resource for image post-processing
- add `RiverModifier` implementation that carves rivers
- allow `IslandGenerator` to apply modifiers after biomes
- enable river example in Main scene

## Testing
- `bash tests/run_all_tests.sh` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bedd41cd0832e864eb1cb3c9f8dc5