### PR TITLE
Add chunk-based infinite world generation

### DIFF
--- a/IslandGeneration/Render/gpu_island_renderer.gd
+++ b/IslandGeneration/Render/gpu_island_renderer.gd
@@ -4,36 +4,33 @@ class_name GPUIslandRenderer
 @export var island_sprite: Sprite2D
 @export var height_scale: float = 20.0
 @export var map_scale: float = 8.0
+@export var player_path: NodePath
+@export var chunk_size: Vector2i = Vector2i(256, 256)
+@export var render_radius: int = 1
 
 func _ready() -> void:
     if not island_sprite:
         island_sprite = Sprite2D.new()
         island_sprite.centered = false
         add_child(island_sprite)
+    _chunks = {}
+    set_process(true)
+
+var _generator: IslandGenerator
+var _biome_threshold_tex: Texture2D
+var _biome_color_tex: Texture2D
+var _biome_count: int = 0
+var _chunks: Dictionary
 
 func generate_island(world_map: WorldMap, generator: IslandGenerator) -> void:
-    if world_map == null or generator == null:
-        push_error("GPUIslandRenderer requires valid WorldMap and IslandGenerator")
+    if generator == null:
+        push_error("GPUIslandRenderer requires a valid IslandGenerator")
         return
 
-    var size: Vector2i = world_map.get_size()
-
-    var hm_tex := ImageTexture.create_from_image(world_map.get_height_map())
-    var temp_tex := ImageTexture.create_from_image(world_map.get_temperature_map())
-
-    #island_sprite.texture = temp_tex
-    island_sprite.scale = Vector2(map_scale, map_scale)
-    # prevent frustrum culling
-
-    var shader_material := island_sprite.material as ShaderMaterial
-    if shader_material == null:
-        shader_material = ShaderMaterial.new()
-        shader_material.shader = load("res://IslandGeneration/Render/Shaders/gpu_island.gdshader")
-        island_sprite.material = shader_material
-
-    shader_material.set_shader_parameter("height_map", hm_tex)
-    shader_material.set_shader_parameter("temperature_map", temp_tex)
-    shader_material.set_shader_parameter("height_scale", height_scale)
+    _generator = generator
+    if world_map:
+        chunk_size = world_map.get_size()
+        _create_chunk(Vector2i.ZERO, world_map)
 
     var colors := PackedColorArray()
     var thresholds := PackedColorArray()
@@ -43,18 +40,76 @@ func generate_island(world_map: WorldMap, generator: IslandGenerator) -> void:
         colors.append(biome.color)
         thresholds.append(Color(biome.min_height, 0.0, biome.min_temperature, biome.max_temperature))
 
-    var count := colors.size()
-    var threshold_img := Image.create(count, 1, false, Image.FORMAT_RGBAF)
-    var color_img := Image.create(count, 1, false, Image.FORMAT_RGBAF)
-    for i in count:
+    _biome_count = colors.size()
+    var threshold_img := Image.create(_biome_count, 1, false, Image.FORMAT_RGBAF)
+    var color_img := Image.create(_biome_count, 1, false, Image.FORMAT_RGBAF)
+    for i in _biome_count:
         threshold_img.set_pixel(i, 0, thresholds[i])
         color_img.set_pixel(i, 0, colors[i])
-    var threshold_tex := ImageTexture.create_from_image(threshold_img)
-    var color_tex := ImageTexture.create_from_image(color_img)
+    _biome_threshold_tex = ImageTexture.create_from_image(threshold_img)
+    _biome_color_tex = ImageTexture.create_from_image(color_img)
 
-    shader_material.set_shader_parameter("biome_thresholds", threshold_tex)
-    shader_material.set_shader_parameter("biome_colors", color_tex)
-    shader_material.set_shader_parameter("biome_count", count)
+    _update_chunks()
+
+func _process(_delta: float) -> void:
+    _update_chunks()
+
+func _get_player() -> Node2D:
+    if player_path == NodePath():
+        return null
+    return get_node_or_null(player_path) as Node2D
+
+func _update_chunks() -> void:
+    var player = _get_player()
+    if player == null or _generator == null:
+        return
+    var cs = chunk_size * map_scale
+    var player_chunk := Vector2i(floor(player.global_position.x / cs.x), floor(player.global_position.y / cs.y))
+    var needed := []
+    for y in range(-render_radius, render_radius + 1):
+        for x in range(-render_radius, render_radius + 1):
+            needed.append(player_chunk + Vector2i(x, y))
+    for coord in needed:
+        if not _chunks.has(coord):
+            _create_chunk(coord)
+    for k in _chunks.keys():
+        if not needed.has(k):
+            var spr = _chunks[k]
+            remove_child(spr)
+            spr.queue_free()
+            _chunks.erase(k)
+
+func _create_chunk(coord: Vector2i, world_map: WorldMap = null) -> void:
+    var wm := world_map if world_map else _generator.generate_map(chunk_size, coord * chunk_size)
+    var sprite: Sprite2D
+    if _chunks.is_empty() and island_sprite:
+        sprite = island_sprite
+        sprite.centered = false
+    else:
+        sprite = Sprite2D.new()
+        sprite.centered = false
+        add_child(sprite)
+    sprite.position = coord * chunk_size * map_scale
+    sprite.scale = Vector2(map_scale, map_scale)
+    _apply_map(sprite, wm)
+    _chunks[coord] = sprite
+
+func _apply_map(sprite: Sprite2D, world_map: WorldMap) -> void:
+    var hm_tex := ImageTexture.create_from_image(world_map.get_height_map())
+    var temp_tex := ImageTexture.create_from_image(world_map.get_temperature_map())
+    var shader_material := sprite.material as ShaderMaterial
+    if shader_material == null:
+        shader_material = ShaderMaterial.new()
+        shader_material.shader = load("res://IslandGeneration/Render/Shaders/gpu_island.gdshader")
+        sprite.material = shader_material
+    shader_material.set_shader_parameter("height_map", hm_tex)
+    shader_material.set_shader_parameter("temperature_map", temp_tex)
+    shader_material.set_shader_parameter("height_scale", height_scale)
+    shader_material.set_shader_parameter("biome_thresholds", _biome_threshold_tex)
+    shader_material.set_shader_parameter("biome_colors", _biome_color_tex)
+    shader_material.set_shader_parameter("biome_count", _biome_count)
 
 func get_texture() -> Texture2D:
-    return island_sprite.texture if island_sprite else null
+    if _chunks.size() > 0:
+        return _chunks.values()[0].texture
+    return null

--- a/IslandGeneration/Render/gpu_island_renderer.gd
+++ b/IslandGeneration/Render/gpu_island_renderer.gd
@@ -30,7 +30,8 @@ func generate_island(world_map: WorldMap, generator: IslandGenerator) -> void:
     _generator = generator
     if world_map:
         chunk_size = world_map.get_size()
-        _create_chunk(Vector2i.ZERO, world_map)
+
+    _clear_chunks()
 
     var colors := PackedColorArray()
     var thresholds := PackedColorArray()
@@ -49,10 +50,28 @@ func generate_island(world_map: WorldMap, generator: IslandGenerator) -> void:
     _biome_threshold_tex = ImageTexture.create_from_image(threshold_img)
     _biome_color_tex = ImageTexture.create_from_image(color_img)
 
+    _refresh_all_chunks(world_map)
     _update_chunks()
 
 func _process(_delta: float) -> void:
     _update_chunks()
+
+func _clear_chunks() -> void:
+    for sprite in _chunks.values():
+        if sprite != island_sprite:
+            remove_child(sprite)
+            sprite.queue_free()
+    _chunks.clear()
+
+func _refresh_all_chunks(world_map: WorldMap = null) -> void:
+    if _chunks.is_empty():
+        if world_map:
+            _create_chunk(Vector2i.ZERO, world_map)
+        return
+    for coord in _chunks.keys():
+        var spr: Sprite2D = _chunks[coord]
+        var wm = _generator.generate_map(chunk_size, coord * chunk_size)
+        _apply_map(spr, wm)
 
 func _get_player() -> Node2D:
     if player_path == NodePath():

--- a/IslandGeneration/island_generator.gd
+++ b/IslandGeneration/island_generator.gd
@@ -18,7 +18,7 @@ func init():
     _initialised = true
 
 
-func generate_map(island_size) -> WorldMap:
+func generate_map(island_size, offset: Vector2i = Vector2i.ZERO) -> WorldMap:
     if not _initialised:
         init()
 
@@ -26,7 +26,7 @@ func generate_map(island_size) -> WorldMap:
         push_error("IslandGenerator requires a WorldMapGenerator")
         return null
 
-    var world_map := map_generator.generate_map(island_size)
+    var world_map := map_generator.generate_map(island_size, offset)
 
     # for y in island_size.y:
     #     for x in island_size.x:

--- a/Scenes/Main/Main.tscn
+++ b/Scenes/Main/Main.tscn
@@ -31,6 +31,9 @@ island_generator = ExtResource("2_o8wgc")
 position = Vector2(-1, -4)
 island_sprite = NodePath("Sprite2D")
 map_scale = 1.0
+player_path = NodePath("../Player")
+chunk_size = Vector2i(256, 256)
+render_radius = 1
 
 [node name="Sprite2D" type="Sprite2D" parent="GpuIslandRenderer"]
 material = SubResource("ShaderMaterial_4vhfm")

--- a/Scenes/Main/main.gd
+++ b/Scenes/Main/main.gd
@@ -5,28 +5,12 @@ extends Node2D
 @export var island_generator: IslandGenerator
 
 func _ready():
-    # Generate the island map data
-    var world_map = island_generator.generate_map(island_size)
-
-    # Start the island generation process
-    island_renderer.generate_island(world_map, island_generator)
-
-    # Set the debug sprite texture if available
-    set_debug_sprite_texture(world_map)
+    island_renderer.generate_island(null, island_generator)
 
 
 
-func set_debug_sprite_texture(world_map: WorldMap) -> void:
-    var debug_sprite: Sprite2D = get_node("CanvasLayer/DebugSprite")
-    if debug_sprite:
-        var image: Image = world_map.get_height_map()
-
-        var h: Texture2D = ImageTexture.create_from_image(image)
-        debug_sprite.texture = h
 
 func _input(event):
     if event.is_action_pressed("ui_accept"):
         print("Regenerating island...")
-        var height_map = island_generator.generate_map(island_size)
-        island_renderer.generate_island(height_map, island_generator)
-        set_debug_sprite_texture(height_map)
+        island_renderer.generate_island(null, island_generator)


### PR DESCRIPTION
## Summary
- extend `world_map_generator.gd` with offset support and optional island mask
- update `island_generator.gd` to forward offset
- overhaul `gpu_island_renderer.gd` to load chunks around the player
- wire up new properties in `Main.tscn`
- simplify `main.gd` usage with chunk rendering

## Testing
- `./tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854bd2c564c832ebd6a846a6a4fe97c